### PR TITLE
Support powershell

### DIFF
--- a/autoload/gutentags.vim
+++ b/autoload/gutentags.vim
@@ -103,7 +103,11 @@ endfunction
 " into a list of unquoted arguments on Unix/Mac.
 if has('win32') || has('win64')
     function! gutentags#make_args(cmd) abort
-        return join(a:cmd, ' ')
+        if &shell == 'pwsh' || &shell == 'powershell'
+            return '& ' . join(a:cmd, ' ')
+        else
+            return join(a:cmd, ' ')
+        endif
     endfunction
 else
     function! gutentags#make_args(cmd) abort


### PR DESCRIPTION
* Powershell takes double quoted "arguments" literally and just errors out on a gutentags call
* You could unquote all the strings and try to deal with the mess that is
* Or you can just prepend '& ' to the whole thing and it automagically works
🤷‍♂️